### PR TITLE
Fix #15 - JAX ontology interface change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### [unreleased]
+### [1.2.2]
 #### Fixed
 - Adding manual HPO terms was broken - updated JAX Ontology API Term Interface to fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### [unreleased]
+#### Fixed
+- Adding manual HPO terms was broken - updated JAX Ontology API Term Interface to fix
+
 ### [1.2.0]
 #### Added
 - A CHANGELOG

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-ts",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-ts",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-ts",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/hpoJax.ts
+++ b/src/hpoJax.ts
@@ -1,29 +1,9 @@
 export interface TermResponse {
-  details: Details;
-  relations: Relations;
-}
-
-export interface Relations {
-  termCount: number;
-  parents: Parent[];
-  children: Parent[];
-}
-
-export interface Parent {
-  name: string;
-  id: number;
-  childrenCount: number;
-  ontologyId: string;
-}
-
-export interface Details {
   name: string;
   id: string;
-  altTermIds: string[];
   definition: string;
   comment: string;
   synonyms: string[];
-  isObsolete: boolean;
-  xrefs: string[];
-  pubmedXrefs: string[];
+  xrefs?: string[];
+  descendantCount?: number;
 }

--- a/src/utils/lookupHpoTerm.ts
+++ b/src/utils/lookupHpoTerm.ts
@@ -11,7 +11,7 @@ async function lookupHpoTerm(term: string): Promise<IResult> {
   );
   if (ret.ok) {
     const res = (await ret.json()) as TermResponse;
-    return { term, label: res.details.name };
+    return { term, label: res.name };
   } else {
     return { error: 'Unknown HPO term' };
   }
@@ -20,9 +20,9 @@ async function lookupHpoTerm(term: string): Promise<IResult> {
 export interface IJaxTerm {
   name: string;
   id: string;
-  childrenCount: number;
-  ontologyId: string;
-  synonym?: string;
+  descendantCount: number;
+  xrefs?: string[];
+  synonyms: string[];
 }
 export interface TermsResponse {
   error?: string;


### PR DESCRIPTION
It is still on the version 0.x range after all so can change rapidly.

## Description
### Fixed
- Updated JAX Ontology API Term Interface


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Do attempt to add a new HPO term to a patient form

### Expected test outcome

- [x] Check that the term can be successfully added
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by DN
- [x] "Merge and deploy" approved by DN
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
